### PR TITLE
Fix frontend registration 401 error

### DIFF
--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -49,14 +49,26 @@ const registerUser = asyncHandler(async (req, res) => {
         res.status(400)
         throw new Error(`Role assignment error: ${setRoleError.message}`)
     }
+    
+    // 3. Sign in the user to get an access token
+    const { data: signInData, error: signInError } = await supabase.auth.signInWithPassword({
+        email: email,
+        password: password,
+    });
+    
+    if (signInError) {
+        res.status(400)
+        throw new Error(`Sign in error: ${signInError.message}`)
+    }
 
-    // Send success response
+    // Send success response with token
     res.status(201).json({
         id: userId,
         email: signUpData.user.email,
         firstName: firstName,
         lastName: lastName,
-        role: role   
+        role: role,
+        token: signInData.session.access_token
     })
 })
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Modify the backend registration endpoint to return an access token, resolving a 401 error on frontend Dashboard load.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the registration endpoint did not return a token. After successful registration, the frontend Dashboard would attempt to fetch entries, but without a token, these requests resulted in a 401 Unauthorized error. This change ensures the user object in the frontend state has a token immediately after registration, allowing subsequent API calls to succeed.

---
<a href="https://cursor.com/background-agent?bcId=bc-911f36a5-14d7-4e0f-baa9-9525974f1824">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-911f36a5-14d7-4e0f-baa9-9525974f1824">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>